### PR TITLE
add option to enable CUDA device code debugging

### DIFF
--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
+option(ENABLE_CUDA_DEVICE_DEBUG "Enable generating CUDA device code debug information." OFF)
+
 set(_TARGET_NORMAL normal)
 
 add_executable(${_TARGET_NORMAL})
@@ -9,6 +11,9 @@ target_sources(${_TARGET_NORMAL}
 set_target_properties(${_TARGET_NORMAL} PROPERTIES
   CUDA_CXX_STANDARD 17
 )
+if(ENABLE_CUDA_DEVICE_DEBUG)
+  target_compile_options(${_TARGET_NORMAL} PRIVATE "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
+endif()
 
 # add include path to the cuda_mav.cuh header
 target_link_libraries(${_TARGET_NORMAL} PRIVATE CUDA_MAV_HEADER)
@@ -22,3 +27,6 @@ target_sources(${_TARGET_ANNOTATED}
 set_target_properties(${_TARGET_ANNOTATED} PROPERTIES
   CUDA_CXX_STANDARD 17
 )
+if(ENABLE_CUDA_DEVICE_DEBUG)
+  target_compile_options(${_TARGET_ANNOTATED} PRIVATE "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
+endif()


### PR DESCRIPTION
Add CMake option to enable CUDA device code debugging: `cmake -DCMAKE_BUILD_TYPE=Debug - DENABLE_CUDA_DEVICE_DEBUG=ON`

Device code debugging works only with the `cuda-gdb`. Without this extension, only debug information for the host code is available, if the code was build in debug mode.